### PR TITLE
Server connection

### DIFF
--- a/server/config/connection.js
+++ b/server/config/connection.js
@@ -1,5 +1,9 @@
 const mongoose = require('mongoose');
 
-mongoose.connect(process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017/googlebooks');
+// added useNewUrlParser and useUnifiedTopology due to Deprecation Warnings
+mongoose.connect(process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017/googlebooks', {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+});
 
 module.exports = mongoose.connection;


### PR DESCRIPTION
This update adds useNewUrlParser and useUnifiedTopology as recommended by mongoose's official documentation under Deprecation Warnings.