### PR TITLE
Apollo server express

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "apollo-server-express": "^3.6.2",
     "bcrypt": "^5.0.0",
     "express": "^4.17.1",
     "graphql": "^15.5.0",

--- a/server/server.js
+++ b/server/server.js
@@ -1,10 +1,17 @@
 const express = require('express');
+const {ApolloServer} = require('apollo-server-express')
 const path = require('path');
 const db = require('./config/connection');
-const routes = require('./routes');
+const { authMiddleware } = require('./utils/auth');
+const { typeDefs, resolvers } = require('./schemas');
 
 const app = express();
 const PORT = process.env.PORT || 3001;
+const server = new ApolloServer({
+  context: authMiddleware,
+  typeDefs,
+  resolvers
+})
 
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
@@ -14,8 +21,21 @@ if (process.env.NODE_ENV === 'production') {
   app.use(express.static(path.join(__dirname, '../client/build')));
 }
 
-app.use(routes);
-
-db.once('open', () => {
-  app.listen(PORT, () => console.log(`🌍 Now listening on localhost:${PORT}`));
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, '../client/build/index.html'));
 });
+
+const startApolloServer = async (typeDefs, resolvers) => {
+  await server.start();
+  server.applyMiddleware({ app });
+  
+  db.once('open', () => {
+    app.listen(PORT, () => {
+      console.log(`API server running on port ${PORT}!`);
+      console.log(`Use GraphQL at http://localhost:${PORT}${server.graphqlPath}`);
+    })
+  })
+  };
+
+// Call the async function to start the server
+startApolloServer(typeDefs, resolvers);


### PR DESCRIPTION
This update adds the apollo-server-express (version 3.6.2) npm dependency to the package.json file of the server folder. It also implements the dependency into the server.js file, getting rid of the usage of RESTful routes. Because this uses Apollo Server 3 and not Apollo Server 2, `await server.start()` must be added before calling `server.applyMiddleware`.